### PR TITLE
Auth update for terminus 0.30.0 with jwt api access

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ The project automatically posts to your Terminus server whenever fresh Foxhole d
 1. Create `.env` file with your Terminus details:
    ```bash
    TERMINUS_URL=https://your-terminus-server.com
-   DEVICE_API_KEY=your_device_api_key_here
+   TERMINUS_LOGIN=your_email@example.com
+   TERMINUS_PASSWORD=your_password
    ```
+
+   **Note**: For Terminus 0.30.0+, you need to create a user account via the web UI first. The old `DEVICE_API_KEY` authentication method is no longer supported.
 
 2. Start the service - Terminus posting happens automatically!
 
@@ -141,6 +144,6 @@ foxhole-svg/
 - Verify town coordinates match between API and database
 
 ### Terminus Issues
-- Verify `.env` file has correct `TERMINUS_URL` and `DEVICE_API_KEY`
+- Verify `.env` file has correct `TERMINUS_URL`, `TERMINUS_LOGIN`, and `TERMINUS_PASSWORD`
 - Check Terminus server is accessible
 - Review logs for API errors

--- a/env.example
+++ b/env.example
@@ -4,8 +4,10 @@
 # Your Terminus server URL (e.g., https://your-terminus-server.com)
 TERMINUS_URL=https://your-terminus-server.com
 
-# Your device API key from Terminus
-DEVICE_API_KEY=your_device_api_key_here
+# Your Terminus user account credentials (required for 0.30.0+)
+# Create a user account via the Terminus web UI first
+TERMINUS_LOGIN=your_email@example.com
+TERMINUS_PASSWORD=your_password
 
 # Optional: Port for the web server (default: 3000)
 PORT=3000

--- a/src/server-with-tracking.js
+++ b/src/server-with-tracking.js
@@ -395,7 +395,7 @@ app.listen(port, () => {
   );
 
   // Start the Terminus poster service if environment variables are configured
-  if (process.env.TERMINUS_URL && process.env.DEVICE_API_KEY) {
+  if (process.env.TERMINUS_URL && process.env.TERMINUS_LOGIN && process.env.TERMINUS_PASSWORD) {
     console.log("🌐 Starting Terminus poster service...");
     import("./terminus-poster.js")
       .then((module) => {
@@ -417,7 +417,7 @@ app.listen(port, () => {
       });
   } else {
     console.log(
-      "⚠️  Terminus poster service not started - missing TERMINUS_URL or DEVICE_API_KEY",
+      "⚠️  Terminus poster service not started - missing TERMINUS_URL, TERMINUS_LOGIN, or TERMINUS_PASSWORD",
     );
   }
 });

--- a/src/terminus-poster.js
+++ b/src/terminus-poster.js
@@ -9,13 +9,19 @@ dotenv.config();
 
 // Load environment variables
 const TERMINUS_URL = process.env.TERMINUS_URL;
-const DEVICE_API_KEY = process.env.DEVICE_API_KEY;
+const TERMINUS_LOGIN = process.env.TERMINUS_LOGIN;
+const TERMINUS_PASSWORD = process.env.TERMINUS_PASSWORD;
 
-if (!TERMINUS_URL || !DEVICE_API_KEY) {
+if (!TERMINUS_URL || !TERMINUS_LOGIN || !TERMINUS_PASSWORD) {
   console.error(
-    "Missing required environment variables: TERMINUS_URL and DEVICE_API_KEY",
+    "Missing required environment variables: TERMINUS_URL, TERMINUS_LOGIN, and TERMINUS_PASSWORD",
   );
   console.error("Please create a .env file with these variables");
+  console.error("");
+  console.error("For Terminus 0.30.0+, you need to:");
+  console.error("1. Create a user account via the web UI at your Terminus URL");
+  console.error("2. Add TERMINUS_LOGIN=your_email and TERMINUS_PASSWORD=your_password to .env");
+  console.error("3. The old DEVICE_API_KEY authentication method is no longer supported");
   process.exit(1);
 }
 
@@ -23,14 +29,89 @@ class TerminusPoster {
   constructor() {
     this.generator = new FoxholeSVGGenerator();
     this.screenId = null;
+    this.accessToken = null;
+    this.refreshToken = null;
+  }
+
+  async authenticate() {
+    if (this.accessToken) return this.accessToken;
+
+    try {
+      console.log("Authenticating with Terminus...");
+      const response = await fetch(`${TERMINUS_URL}/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          login: TERMINUS_LOGIN,
+          password: TERMINUS_PASSWORD,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error("Authentication failed:", response.status, errorText);
+        return null;
+      }
+
+      const data = await response.json();
+      this.accessToken = data.access_token;
+      this.refreshToken = data.refresh_token;
+      console.log("✅ Authentication successful");
+      return this.accessToken;
+    } catch (error) {
+      console.error("Error during authentication:", error);
+      return null;
+    }
+  }
+
+  async refreshAccessToken() {
+    if (!this.refreshToken) {
+      console.log("No refresh token available, re-authenticating...");
+      return await this.authenticate();
+    }
+
+    try {
+      console.log("Refreshing access token...");
+      const response = await fetch(`${TERMINUS_URL}/api/jwt`, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${this.accessToken}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          refresh_token: this.refreshToken,
+        }),
+      });
+
+      if (!response.ok) {
+        console.log("Token refresh failed, re-authenticating...");
+        return await this.authenticate();
+      }
+
+      const data = await response.json();
+      this.accessToken = data.access_token;
+      this.refreshToken = data.refresh_token;
+      console.log("✅ Token refreshed successfully");
+      return this.accessToken;
+    } catch (error) {
+      console.error("Error refreshing token:", error);
+      return await this.authenticate();
+    }
   }
 
   async getScreenId() {
     if (this.screenId) return this.screenId;
 
     try {
+      const token = await this.authenticate();
+      if (!token) return null;
+
       const headers = {
-        "Access-Token": DEVICE_API_KEY,
+        "Authorization": `Bearer ${token}`,
         "Content-Type": "application/json",
         Accept: "application/json",
       };
@@ -68,6 +149,12 @@ class TerminusPoster {
 
   async postToTerminus(svgContent) {
     try {
+      const token = await this.authenticate();
+      if (!token) {
+        console.error("❌ Authentication failed, cannot post to Terminus");
+        return;
+      }
+
       const screenId = await this.getScreenId();
       const now = new Date();
 
@@ -83,19 +170,19 @@ class TerminusPoster {
       // Generate HTML wrapper for SVG
       const htmlContent = await this.generateAndSaveHTMLWrapper(svgContent);
 
-              // Create data for HTML upload to Terminus API - using new schema
-        const data = {
-          screen: {
-            content: htmlContent,
-            file_name: `foxhole-epaper-${now.getFullYear()}-${(now.getMonth() + 1).toString().padStart(2, "0")}-${now.getDate().toString().padStart(2, "0")}-${now.getHours().toString().padStart(2, "0")}-${now.getMinutes().toString().padStart(2, "0")}.png`,
-            model_id: "1",
-            label: "Foxhole E-Paper Map",
-            name: "foxhole_epaper_dashboard",
-          },
-        };
+      // Create data for HTML upload to Terminus API - using new schema
+      const data = {
+        screen: {
+          content: htmlContent,
+          file_name: `foxhole-epaper-${now.getFullYear()}-${(now.getMonth() + 1).toString().padStart(2, "0")}-${now.getDate().toString().padStart(2, "0")}-${now.getHours().toString().padStart(2, "0")}-${now.getMinutes().toString().padStart(2, "0")}.png`,
+          model_id: "1",
+          label: "Foxhole E-Paper Map",
+          name: "foxhole_epaper_dashboard",
+        },
+      };
 
       const headers = {
-        "Access-Token": DEVICE_API_KEY,
+        "Authorization": `Bearer ${token}`,
         "Content-Type": "application/json",
         Accept: "application/json",
       };
@@ -105,17 +192,17 @@ class TerminusPoster {
         // Update existing screen (PATCH only supports HTML content)
         const updateUrl = `${TERMINUS_URL}/api/screens/${screenId}`;
         console.log(`Updating existing Foxhole screen ${screenId}`);
-                  response = await fetch(updateUrl, {
-            method: "PATCH",
-            headers,
-            body: JSON.stringify({
-              screen: {
-                content: data.screen.content,
-                label: data.screen.label,
-                name: data.screen.name,
-              },
-            }),
-          });
+        response = await fetch(updateUrl, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({
+            screen: {
+              content: data.screen.content,
+              label: data.screen.label,
+              name: data.screen.name,
+            },
+          }),
+        });
       } else {
         // Create new screen
         const screensUrl = `${TERMINUS_URL}/api/screens`;
@@ -129,7 +216,7 @@ class TerminusPoster {
 
       if (response.ok) {
         const result = await response.json();
-        console.log("Foxhole dashboard published successfully:", result);
+        console.log("✅ Foxhole dashboard published successfully:", result);
 
         // If this was a new screen, save the ID
         if (!screenId && result.data && result.data.id) {
@@ -139,10 +226,21 @@ class TerminusPoster {
       } else {
         const errorText = await response.text();
         console.error(
-          "Error publishing Foxhole dashboard:",
+          "❌ Error publishing Foxhole dashboard:",
           response.status,
           errorText,
         );
+        
+        // If it's an authentication error, try to refresh the token
+        if (response.status === 401) {
+          console.log("🔄 Authentication error, trying to refresh token...");
+          const newToken = await this.refreshAccessToken();
+          if (newToken) {
+            console.log("🔄 Retrying with refreshed token...");
+            // Retry the request with the new token
+            return await this.postToTerminus(svgContent);
+          }
+        }
       }
     } catch (error) {
       console.error("Error posting to Terminus:", error);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces device API key auth with JWT-based login/password for Terminus, adds token refresh and updates env gating and docs.
> 
> - **Backend (Terminus integration)**
>   - Switch from `DEVICE_API_KEY` to JWT auth using `POST /login` and `Authorization: Bearer <token>`.
>   - Implement `authenticate()` and `refreshAccessToken()` using `/api/jwt`; auto-retry on `401`.
>   - Replace headers from `Access-Token` to `Authorization` and add improved logging.
>   - Update `src/server-with-tracking.js` to start poster only when `TERMINUS_URL`, `TERMINUS_LOGIN`, and `TERMINUS_PASSWORD` are set; adjust missing-env message.
> - **Config**
>   - Update `env.example`: remove `DEVICE_API_KEY`; add `TERMINUS_LOGIN` and `TERMINUS_PASSWORD`.
> - **Docs**
>   - Update `README.md` setup and troubleshooting to require `TERMINUS_LOGIN`/`TERMINUS_PASSWORD` (note about 0.30.0+), removing `DEVICE_API_KEY`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f62153bc78d8dc9999614de8565ddb9fbe5d117. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->